### PR TITLE
test JPA con controller REST

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.0
     container_name: zookeeper
+    restart: always
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -11,6 +12,7 @@ services:
   broker:
     image: confluentinc/cp-kafka:7.3.0
     container_name: broker
+    restart: always
     ports:
       - "9092:9092"
     depends_on:
@@ -37,6 +39,8 @@ services:
 
   db:
     image: mariadb:latest
+    container_name: mariadb
+    restart: always
     environment:
       MARIADB_ROOT_PASSWORD: root
       MARIADB_DATABASE: serveeasy

--- a/src/main/java/com/example/gestionecomanda/Domain/GestionePrioritaOrdini.java
+++ b/src/main/java/com/example/gestionecomanda/Domain/GestionePrioritaOrdini.java
@@ -1,13 +1,21 @@
 package com.example.gestionecomanda.Domain;
 
+import com.example.gestionecomanda.Domain.DTO.ClienteDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
-public class GestionePrioritaOrdini {
+public class GestionePrioritaOrdini implements TestPort{
+    private final DataPort dataPort;
 
     @Autowired
-    @Qualifier("JPADBAdapter")
-    private DataPort dataPort;
+    public GestionePrioritaOrdini(@Qualifier("jpadbAdapter") DataPort dataPort) {
+        this.dataPort = dataPort;
+    }
+
+    @Override
+    public Iterable<ClienteDTO> getClienti() {
+        return dataPort.getClienti();
+    }
 }

--- a/src/main/java/com/example/gestionecomanda/Domain/TestPort.java
+++ b/src/main/java/com/example/gestionecomanda/Domain/TestPort.java
@@ -1,0 +1,8 @@
+package com.example.gestionecomanda.Domain;
+
+import com.example.gestionecomanda.Domain.DTO.ClienteDTO;
+
+public interface TestPort {
+
+    Iterable<ClienteDTO> getClienti();
+}

--- a/src/main/java/com/example/gestionecomanda/Interface/testControllers/TestController.java
+++ b/src/main/java/com/example/gestionecomanda/Interface/testControllers/TestController.java
@@ -1,8 +1,11 @@
 package com.example.gestionecomanda.Interface.testControllers;
 
+import com.example.gestionecomanda.Domain.DTO.ClienteDTO;
+import com.example.gestionecomanda.Domain.TestPort;
 import com.example.gestionecomanda.Interface.testControllers.impl.TestServiceImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +20,7 @@ import java.util.Optional;
 public class TestController {
 
     private TestService testService;
+    private TestPort testport;
 
     @Value("${spring.kafka.consumer.gestioneCliente.topic}")
     private String topic_notifyOrderEvent;
@@ -25,9 +29,21 @@ public class TestController {
     private String topic_notifyPrepEvent;
 
     @Autowired
-    public TestController(TestServiceImpl testService) {
+    public TestController(TestServiceImpl testService, @Qualifier("gestionePrioritaOrdini") TestPort testport) {
         this.testService = testService;
+        this.testport = testport;
     }
+
+
+    /**
+     * Espone una API di GET con la quale è possibile richiedere al database tutti i clienti
+     * @return una lista di oggetti Cliente serializzati
+     */
+    @GetMapping(path = "/test/clienti")
+    public Iterable<ClienteDTO> getClienti(){
+        return testport.getClienti();
+    }
+
 
     /**
      * Espone una API di POST con la quale è possibile iniettare all'interno del broker oggetti al fine di test

--- a/src/main/java/com/example/gestionecomanda/config/InterfaceConfiguration.java
+++ b/src/main/java/com/example/gestionecomanda/config/InterfaceConfiguration.java
@@ -1,0 +1,17 @@
+package com.example.gestionecomanda.config;
+
+import com.example.gestionecomanda.Domain.DataPort;
+import com.example.gestionecomanda.Domain.GestionePrioritaOrdini;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class InterfaceConfiguration {
+
+    @Bean
+    GestionePrioritaOrdini gestionePrioritaOrdini(@Qualifier("jpadbAdapter") DataPort dataPort){
+        return new GestionePrioritaOrdini(dataPort);
+    }
+
+}


### PR DESCRIPTION
- creato interface TestPort per inserire operazione di test

-modificato GestionePrioritaOrdini per implementare interface TestPort e utilizzare porta DataPort verso Infrastructure/Repository, implementata come JPADBAdapter con bean specificato da @Qualifier

-aggiunto @Bean per GestionePrioritaOrdini in InterfaceConfiguration nelle configurazioni

-modificato TestController per utilizzare porta TestPort verso Dominio implementata come GestionePrioritaOrdini con bean specificato da @Qualifier

-modificato TestController per aggiungere GetMapping per richiedere lista clienti