### PR TITLE
heathcheck Dockerizzazione di GestioneComanda

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,32 @@
 ---
-version: '3'
+version: '3.4'
 services:
+
+  GestioneComanda:
+    image: serveeasy/gestione_comanda:latest
+    build: .
+    container_name: GestioneComanda
+    restart: always
+    environment:
+      SERVER_PORT: 8080
+      SERVER_ADDRESS: 0.0.0.0
+      SPRING_DATASOURCE_URL: jdbc:mariadb://db:3306/serveeasy
+      SPRING_KAFKA_BOOTSTRAP-SERVERS: broker:29092 #plaintext_internal
+    depends_on:
+      db:
+        condition: service_healthy
+      broker:
+        condition: service_started
+    healthcheck:
+      test: "curl --fail --silent localhost:8080/actuator/health | grep UP || exit 1"
+      interval: 20s
+      timeout: 5s
+      start_period: 40s
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"
+
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.0
     container_name: zookeeper

--- a/pom.xml
+++ b/pom.xml
@@ -18,17 +18,6 @@
     </properties>
     <dependencies>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -107,6 +96,25 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- mariadb -->
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- actuator-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/example/gestionecomanda/Interface/testControllers/TestController.java
+++ b/src/main/java/com/example/gestionecomanda/Interface/testControllers/TestController.java
@@ -43,7 +43,6 @@ public class TestController {
         return testport.getClienti();
     }
 
-
     /**
      * Espone una API di POST con la quale è possibile iniettare all'interno del broker oggetti al fine di test
      * Si testa il topic sendOrderEvent da gestione comanda verso gestione cucina

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+server.address=localhost
+server.port=8080
+
 spring.application.name=GestioneComanda
 gestionecomanda.gestionecucina.topic=cucina.ordini
 


### PR DESCRIPTION
aggiunto attuatore per poter effettuare l'healthcheck dell'app dockerizzata seguendo gli standard

creato immagine serveeasy/gestione_comanda tramite Dockerfile (presto upload su Docker Hub).

testato container, disponibilità, healthcheck, connessione ai servizi kafka su PLAINTEXT_INTERNAL, messaggi in rete kafka tramite kafdrop